### PR TITLE
Use AtomicInteger for naming of ParameterExpressions to avoid conflicts ...

### DIFF
--- a/src/main/java/net/hydromatic/linq4j/expressions/ParameterExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/ParameterExpression.java
@@ -19,18 +19,19 @@ package net.hydromatic.linq4j.expressions;
 
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Represents a named parameter expression.
  */
 public class ParameterExpression extends Expression {
-  private static int seq = 0;
+  private static AtomicInteger seq = new AtomicInteger();
 
   public final int modifier;
   public final String name;
 
   public ParameterExpression(Type type) {
-    this(0, type, "p" + seq++);
+    this(0, type, "p" + seq.getAndIncrement());
   }
 
   public ParameterExpression(int modifier, Type type, String name) {


### PR DESCRIPTION
...in multithreaded usage
