### PR TITLE
Implement equals and hashCode for expressions.

### DIFF
--- a/src/main/java/net/hydromatic/linq4j/expressions/AbstractNode.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/AbstractNode.java
@@ -68,6 +68,34 @@ public abstract class AbstractNode implements Node {
     throw new RuntimeException(
         "evaluation not supported: " + getClass() + ":" + nodeType);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AbstractNode that = (AbstractNode) o;
+
+    if (nodeType != that.nodeType) {
+      return false;
+    }
+    if (type != null ? !type.equals(that.type) : that.type != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = nodeType != null ? nodeType.hashCode() : 0;
+    result = 31 * result + (type != null ? type.hashCode() : 0);
+    return result;
+  }
 }
 
 // End AbstractNode.java

--- a/src/main/java/net/hydromatic/linq4j/expressions/ArrayLengthRecordField.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/ArrayLengthRecordField.java
@@ -17,32 +17,45 @@
 */
 package net.hydromatic.linq4j.expressions;
 
+import java.lang.reflect.Array;
+import java.lang.reflect.Type;
+
 /**
- * Represents a "while" statement.
+ * Represents a length field of a RecordType
  */
-public class WhileStatement extends Statement {
-  public final Expression condition;
-  public final Statement body;
+public class ArrayLengthRecordField implements Types.RecordField {
+  private final String fieldName;
+  private final Class clazz;
 
-  public WhileStatement(Expression condition, Statement body) {
-    super(ExpressionType.While, Void.TYPE);
-    assert condition != null : "condition should not be null";
-    assert body != null : "body should not be null";
-    this.condition = condition;
-    this.body = body;
+  public ArrayLengthRecordField(String fieldName, Class clazz) {
+    assert fieldName != null : "fieldName should not be null";
+    assert clazz != null : "clazz should not be null";
+    this.fieldName = fieldName;
+    this.clazz = clazz;
   }
 
-  @Override
-  public Statement accept(Visitor visitor) {
-    final Expression condition1 = condition.accept(visitor);
-    final Statement body1 = body.accept(visitor);
-    return visitor.visit(this, condition1, body1);
+  public boolean nullable() {
+    return false;
   }
 
-  @Override
-  void accept0(ExpressionWriter writer) {
-    writer.append("while (").append(condition).append(") ").append(
-        Blocks.toBlock(body));
+  public String getName() {
+    return fieldName;
+  }
+
+  public Type getType() {
+    return int.class;
+  }
+
+  public int getModifiers() {
+    return 0;
+  }
+
+  public Object get(Object o) throws IllegalAccessException {
+    return Array.getLength(o);
+  }
+
+  public Type getDeclaringClass() {
+    return clazz;
   }
 
   @Override
@@ -53,16 +66,13 @@ public class WhileStatement extends Statement {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    if (!super.equals(o)) {
+
+    ArrayLengthRecordField that = (ArrayLengthRecordField) o;
+
+    if (!clazz.equals(that.clazz)) {
       return false;
     }
-
-    WhileStatement that = (WhileStatement) o;
-
-    if (!body.equals(that.body)) {
-      return false;
-    }
-    if (!condition.equals(that.condition)) {
+    if (!fieldName.equals(that.fieldName)) {
       return false;
     }
 
@@ -71,11 +81,8 @@ public class WhileStatement extends Statement {
 
   @Override
   public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + condition.hashCode();
-    result = 31 * result + body.hashCode();
+    int result = fieldName.hashCode();
+    result = 31 * result + clazz.hashCode();
     return result;
   }
 }
-
-// End WhileStatement.java

--- a/src/main/java/net/hydromatic/linq4j/expressions/BinaryExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/BinaryExpression.java
@@ -30,31 +30,11 @@ public class BinaryExpression extends Expression {
   BinaryExpression(ExpressionType nodeType, Type type, Expression expression0,
       Expression expression1) {
     super(nodeType, type);
+    assert expression0 != null : "expression0 should not be null";
+    assert expression1 != null : "expression1 should not be null";
     this.expression0 = expression0;
     this.expression1 = expression1;
     this.primitive = Primitive.of(expression0.getType());
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (obj == this) {
-      return true;
-    }
-    if (obj instanceof BinaryExpression) {
-      final BinaryExpression binary = (BinaryExpression) obj;
-      return nodeType == binary.nodeType
-             && type.equals(binary.type)
-             && expression0.equals(binary.expression0)
-             && expression1.equals(binary.expression1);
-    }
-    return false;
-  }
-
-  @Override
-  public int hashCode() {
-    return nodeType.hashCode()
-           ^ expression0.hashCode()
-           ^ expression1.hashCode();
   }
 
   @Override
@@ -187,6 +167,42 @@ public class BinaryExpression extends Expression {
                                 + nodeType
                                 + ", primitive="
                                 + primitive);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    BinaryExpression that = (BinaryExpression) o;
+
+    if (!expression0.equals(that.expression0)) {
+      return false;
+    }
+    if (!expression1.equals(that.expression1)) {
+      return false;
+    }
+    if (primitive != that.primitive) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + expression0.hashCode();
+    result = 31 * result + expression1.hashCode();
+    result = 31 * result + (primitive != null ? primitive.hashCode() : 0);
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/BlockBuilder.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/BlockBuilder.java
@@ -85,7 +85,7 @@ public class BlockBuilder {
     }
     Expression result = null;
     final Map<ParameterExpression, Expression> replacements =
-        new HashMap<ParameterExpression, Expression>();
+        new IdentityHashMap<ParameterExpression, Expression>();
     final Visitor visitor = new SubstituteVariableVisitor(replacements);
     for (int i = 0; i < block.statements.size(); i++) {
       Statement statement = block.statements.get(i);
@@ -101,7 +101,11 @@ public class BlockBuilder {
               declaration.initializer);
           statement = null;
           result = x;
-          replacements.put(declaration.parameter, x);
+          if (declaration.parameter != x) {
+            // declaration.parameter can be equal to x if exactly the same
+            // declaration was present in BlockBuilder
+            replacements.put(declaration.parameter, x);
+          }
         } else {
           add(statement);
         }
@@ -240,7 +244,7 @@ public class BlockBuilder {
       statement.accept(useCounter);
     }
     final Map<ParameterExpression, Expression> subMap =
-        new HashMap<ParameterExpression, Expression>();
+        new IdentityHashMap<ParameterExpression, Expression>();
     final SubstituteVariableVisitor visitor = new SubstituteVariableVisitor(
         subMap);
     final ArrayList<Statement> oldStatements = new ArrayList<Statement>(
@@ -360,7 +364,7 @@ public class BlockBuilder {
 
   private static class UseCounter extends Visitor {
     private final Map<ParameterExpression, Slot> map =
-        new HashMap<ParameterExpression, Slot>();
+        new IdentityHashMap<ParameterExpression, Slot>();
 
     public Expression visit(ParameterExpression parameter) {
       final Slot slot = map.get(parameter);

--- a/src/main/java/net/hydromatic/linq4j/expressions/BlockStatement.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/BlockStatement.java
@@ -28,9 +28,14 @@ import java.util.Set;
  */
 public class BlockStatement extends Statement {
   public final List<Statement> statements;
+  /**
+   * Cache the hash code for the expression
+   */
+  private int hash;
 
   BlockStatement(List<Statement> statements, Type type) {
     super(ExpressionType.Block, type);
+    assert statements != null : "statements should not be null";
     this.statements = statements;
     assert distinctVariables(true);
   }
@@ -76,6 +81,41 @@ public class BlockStatement extends Statement {
       o = statement.evaluate(evaluator);
     }
     return o;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    BlockStatement that = (BlockStatement) o;
+
+    if (!statements.equals(that.statements)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = hash;
+    if (result == 0) {
+      result = super.hashCode();
+      result = 31 * result + statements.hashCode();
+      if (result == 0) {
+        result = 1;
+      }
+      hash = result;
+    }
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/ClassDeclaration.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/ClassDeclaration.java
@@ -34,6 +34,7 @@ public class ClassDeclaration extends MemberDeclaration {
 
   public ClassDeclaration(int modifier, String name, Type extended,
       List<Type> implemented, List<MemberDeclaration> memberDeclarations) {
+    assert name != null : "name should not be null";
     this.modifier = modifier;
     this.name = name;
     this.memberDeclarations = memberDeclarations;
@@ -62,6 +63,54 @@ public class ClassDeclaration extends MemberDeclaration {
     final List<MemberDeclaration> members1 =
         Expressions.acceptMemberDeclarations(memberDeclarations, visitor);
     return visitor.visit(this, members1);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ClassDeclaration that = (ClassDeclaration) o;
+
+    if (modifier != that.modifier) {
+      return false;
+    }
+    if (!classClass.equals(that.classClass)) {
+      return false;
+    }
+    if (extended != null ? !extended.equals(that.extended) : that.extended
+        != null) {
+      return false;
+    }
+    if (implemented != null ? !implemented.equals(that.implemented) : that
+        .implemented != null) {
+      return false;
+    }
+    if (memberDeclarations != null ? !memberDeclarations.equals(that
+        .memberDeclarations) : that.memberDeclarations != null) {
+      return false;
+    }
+    if (!name.equals(that.name)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = modifier;
+    result = 31 * result + classClass.hashCode();
+    result = 31 * result + name.hashCode();
+    result = 31 * result + (memberDeclarations != null ? memberDeclarations
+        .hashCode() : 0);
+    result = 31 * result + (extended != null ? extended.hashCode() : 0);
+    result = 31 * result + (implemented != null ? implemented.hashCode() : 0);
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/ConditionalExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/ConditionalExpression.java
@@ -37,6 +37,7 @@ public class ConditionalExpression extends AbstractNode {
 
   public ConditionalExpression(List<Node> expressionList, Type type) {
     super(ExpressionType.Conditional, type);
+    assert expressionList != null : "expressionList should not be null";
     this.expressionList = expressionList;
   }
 
@@ -52,6 +53,34 @@ public class ConditionalExpression extends AbstractNode {
       writer.append(" else ").append(Blocks.toBlock(expressionList.get(
           expressionList.size() - 1)));
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    ConditionalExpression that = (ConditionalExpression) o;
+
+    if (!expressionList.equals(that.expressionList)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + expressionList.hashCode();
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/ConditionalStatement.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/ConditionalStatement.java
@@ -36,6 +36,7 @@ public class ConditionalStatement extends Statement {
 
   public ConditionalStatement(List<Node> expressionList) {
     super(ExpressionType.Conditional, Void.TYPE);
+    assert expressionList != null : "expressionList should not be null";
     this.expressionList = expressionList;
   }
 
@@ -60,6 +61,34 @@ public class ConditionalStatement extends Statement {
       writer.append(" else ").append(Blocks.toBlock(expressionList.get(
           expressionList.size() - 1)));
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    ConditionalStatement that = (ConditionalStatement) o;
+
+    if (!expressionList.equals(that.expressionList)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + expressionList.hashCode();
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/ConstantExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/ConstantExpression.java
@@ -17,7 +17,6 @@
 */
 package net.hydromatic.linq4j.expressions;
 
-import net.hydromatic.linq4j.Linq4j;
 import net.hydromatic.linq4j.function.Function1;
 import net.hydromatic.linq4j.function.Functions;
 
@@ -50,20 +49,6 @@ public class ConstantExpression extends Expression {
         }
       }
     }
-  }
-
-  @Override
-  public int hashCode() {
-    return value == null ? 1 : value.hashCode();
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    // REVIEW: Should constants with the same value and different type
-    // (e.g. 3L and 3) be considered equal.
-    return obj == this
-           || obj instanceof ConstantExpression
-              && Linq4j.equals(value, ((ConstantExpression) obj).value);
   }
 
   public Object evaluate(Evaluator evaluator) {
@@ -244,6 +229,36 @@ public class ConstantExpression extends Expression {
       lastChar = c;
     }
     buf.append('"');
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    // REVIEW: Should constants with the same value and different type
+    // (e.g. 3L and 3) be considered equal.
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    ConstantExpression that = (ConstantExpression) o;
+
+    if (value != null ? !value.equals(that.value) : that.value != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (value != null ? value.hashCode() : 0);
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/ConstructorDeclaration.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/ConstructorDeclaration.java
@@ -32,9 +32,16 @@ public class ConstructorDeclaration extends MemberDeclaration {
   public final Type resultType;
   public final List<ParameterExpression> parameters;
   public final BlockStatement body;
+  /**
+   * Cache the hash code for the expression
+   */
+  private int hash;
 
   public ConstructorDeclaration(int modifier, Type declaredAgainst,
       List<ParameterExpression> parameters, BlockStatement body) {
+    assert parameters != null : "parameters should not be null";
+    assert body != null : "body should not be null";
+    assert declaredAgainst != null : "declaredAgainst should not be null";
     this.modifier = modifier;
     this.resultType = declaredAgainst;
     this.parameters = parameters;
@@ -69,6 +76,49 @@ public class ConstructorDeclaration extends MemberDeclaration {
                 }))
         .append(' ').append(body);
     writer.newlineAndIndent();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ConstructorDeclaration that = (ConstructorDeclaration) o;
+
+    if (modifier != that.modifier) {
+      return false;
+    }
+    if (!body.equals(that.body)) {
+      return false;
+    }
+    if (!parameters.equals(that.parameters)) {
+      return false;
+    }
+    if (!resultType.equals(that.resultType)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = hash;
+    if (result == 0) {
+      result = modifier;
+      result = 31 * result + resultType.hashCode();
+      result = 31 * result + parameters.hashCode();
+      result = 31 * result + body.hashCode();
+      if (result == 0) {
+        result = 1;
+      }
+      hash = result;
+    }
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/DeclarationStatement.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/DeclarationStatement.java
@@ -30,6 +30,7 @@ public class DeclarationStatement extends Statement {
   public DeclarationStatement(int modifiers, ParameterExpression parameter,
       Expression initializer) {
     super(ExpressionType.Declaration, Void.TYPE);
+    assert parameter != null : "parameter should not be null";
     this.modifiers = modifiers;
     this.parameter = parameter;
     this.initializer = initializer;
@@ -72,6 +73,43 @@ public class DeclarationStatement extends Statement {
     if (initializer != null) {
       writer.append(" = ").append(initializer);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    DeclarationStatement that = (DeclarationStatement) o;
+
+    if (modifiers != that.modifiers) {
+      return false;
+    }
+    if (initializer != null ? !initializer.equals(that.initializer) : that
+        .initializer != null) {
+      return false;
+    }
+    if (!parameter.equals(that.parameter)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + modifiers;
+    result = 31 * result + parameter.hashCode();
+    result = 31 * result + (initializer != null ? initializer.hashCode() : 0);
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/FieldDeclaration.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/FieldDeclaration.java
@@ -29,6 +29,7 @@ public class FieldDeclaration extends MemberDeclaration {
 
   public FieldDeclaration(int modifier, ParameterExpression parameter,
       Expression initializer) {
+    assert parameter != null : "parameter should not be null";
     this.modifier = modifier;
     this.parameter = parameter;
     this.initializer = initializer;
@@ -54,6 +55,39 @@ public class FieldDeclaration extends MemberDeclaration {
     }
     writer.append(';');
     writer.newlineAndIndent();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    FieldDeclaration that = (FieldDeclaration) o;
+
+    if (modifier != that.modifier) {
+      return false;
+    }
+    if (initializer != null ? !initializer.equals(that.initializer) : that
+        .initializer != null) {
+      return false;
+    }
+    if (!parameter.equals(that.parameter)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = modifier;
+    result = 31 * result + parameter.hashCode();
+    result = 31 * result + (initializer != null ? initializer.hashCode() : 0);
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/ForStatement.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/ForStatement.java
@@ -29,6 +29,10 @@ public class ForStatement extends Statement {
   public final Expression condition;
   public final Expression post;
   public final Statement body;
+  /**
+   * Cache the hash code for the expression
+   */
+  private int hash;
 
   public ForStatement(List<DeclarationStatement> declarations,
       Expression condition, Expression post, Statement body) {
@@ -67,6 +71,54 @@ public class ForStatement extends Statement {
       writer.append(post);
     }
     writer.append(") ").append(Blocks.toBlock(body));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    ForStatement that = (ForStatement) o;
+
+    if (!body.equals(that.body)) {
+      return false;
+    }
+    if (condition != null ? !condition.equals(that.condition) : that
+        .condition != null) {
+      return false;
+    }
+    if (!declarations.equals(that.declarations)) {
+      return false;
+    }
+    if (post != null ? !post.equals(that.post) : that.post != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = hash;
+    if (result == 0) {
+      result = super.hashCode();
+      result = 31 * result + declarations.hashCode();
+      result = 31 * result + (condition != null ? condition.hashCode() : 0);
+      result = 31 * result + (post != null ? post.hashCode() : 0);
+      result = 31 * result + body.hashCode();
+      if (result == 0) {
+        result = 1;
+      }
+      hash = result;
+    }
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/FunctionExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/FunctionExpression.java
@@ -34,12 +34,18 @@ public final class FunctionExpression<F extends Function<?>>
   public final BlockStatement body;
   public final List<ParameterExpression> parameterList;
   private F dynamicFunction;
+  /**
+   * Cache the hash code for the expression
+   */
+  private int hash;
 
   private FunctionExpression(Class<F> type, F function, BlockStatement body,
       List<ParameterExpression> parameterList) {
     super(ExpressionType.Lambda, type);
-    assert type != null;
-    assert function != null || body != null;
+    assert type != null : "type should not be null";
+    assert function != null || body != null : "both function and body should "
+        + "not be null";
+    assert parameterList != null : "parameterList should not be null";
     this.function = function;
     this.body = body;
     this.parameterList = parameterList;
@@ -194,6 +200,50 @@ public final class FunctionExpression<F extends Function<?>>
       return "call"; // FIXME
     }
     return "apply";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    FunctionExpression that = (FunctionExpression) o;
+
+    if (body != null ? !body.equals(that.body) : that.body != null) {
+      return false;
+    }
+    if (function != null ? !function.equals(that.function) : that.function
+        != null) {
+      return false;
+    }
+    if (!parameterList.equals(that.parameterList)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = hash;
+    if (result == 0) {
+      result = super.hashCode();
+      result = 31 * result + (function != null ? function.hashCode() : 0);
+      result = 31 * result + (body != null ? body.hashCode() : 0);
+      result = 31 * result + parameterList.hashCode();
+      if (result == 0) {
+        result = 1;
+      }
+      hash = result;
+    }
+    return result;
   }
 
   /** Function that can be invoked with a variable number of arguments. */

--- a/src/main/java/net/hydromatic/linq4j/expressions/GotoStatement.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/GotoStatement.java
@@ -30,6 +30,7 @@ public class GotoStatement extends Statement {
       Expression expression) {
     super(ExpressionType.Goto,
         expression == null ? Void.TYPE : expression.getType());
+    assert kind != null : "kind should not be null";
     this.kind = kind;
     this.labelTarget = labelTarget;
     this.expression = expression;
@@ -94,6 +95,44 @@ public class GotoStatement extends Statement {
     default:
       throw new AssertionError("evaluate not implemented");
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    GotoStatement that = (GotoStatement) o;
+
+    if (expression != null ? !expression.equals(that.expression) : that
+        .expression != null) {
+      return false;
+    }
+    if (kind != that.kind) {
+      return false;
+    }
+    if (labelTarget != null ? !labelTarget.equals(that.labelTarget) : that
+        .labelTarget != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + kind.hashCode();
+    result = 31 * result + (labelTarget != null ? labelTarget.hashCode() : 0);
+    result = 31 * result + (expression != null ? expression.hashCode() : 0);
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/IndexExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/IndexExpression.java
@@ -28,28 +28,11 @@ public class IndexExpression extends Expression {
 
   public IndexExpression(Expression array, List<Expression> indexExpressions) {
     super(ExpressionType.ArrayIndex, Types.getComponentType(array.getType()));
+    assert array != null : "array should not be null";
+    assert indexExpressions != null : "indexExpressions should not be null";
+    assert !indexExpressions.isEmpty() : "indexExpressions should not be empty";
     this.array = array;
     this.indexExpressions = indexExpressions;
-    assert indexExpressions.size() >= 1;
-  }
-
-  @Override
-  public int hashCode() {
-    return nodeType.hashCode() ^ array.hashCode() ^ indexExpressions.hashCode();
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj instanceof IndexExpression) {
-      final IndexExpression indexExpression = (IndexExpression) obj;
-      return nodeType == indexExpression.nodeType
-          && array.equals(indexExpression.array)
-          && indexExpressions.equals(indexExpression.indexExpressions);
-    }
-    return false;
   }
 
   @Override
@@ -65,6 +48,38 @@ public class IndexExpression extends Expression {
   void accept(ExpressionWriter writer, int lprec, int rprec) {
     array.accept(writer, lprec, nodeType.lprec);
     writer.list("[", ", ", "]", indexExpressions);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    IndexExpression that = (IndexExpression) o;
+
+    if (!array.equals(that.array)) {
+      return false;
+    }
+    if (!indexExpressions.equals(that.indexExpressions)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + array.hashCode();
+    result = 31 * result + indexExpressions.hashCode();
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/LabelStatement.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/LabelStatement.java
@@ -36,6 +36,35 @@ public class LabelStatement extends Statement {
   public LabelStatement accept(Visitor visitor) {
     return visitor.visit(this);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    LabelStatement that = (LabelStatement) o;
+
+    if (defaultValue != null ? !defaultValue.equals(that.defaultValue) : that
+        .defaultValue != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
+    return result;
+  }
 }
 
 // End LabelStatement.java

--- a/src/main/java/net/hydromatic/linq4j/expressions/LabelTarget.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/LabelTarget.java
@@ -26,6 +26,29 @@ public class LabelTarget {
   public LabelTarget(String name) {
     this.name = name;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    LabelTarget that = (LabelTarget) o;
+
+    if (name != null ? !name.equals(that.name) : that.name != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return name != null ? name.hashCode() : 0;
+  }
 }
 
 // End LabelTarget.java

--- a/src/main/java/net/hydromatic/linq4j/expressions/MemberExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/MemberExpression.java
@@ -33,10 +33,11 @@ public class MemberExpression extends Expression {
 
   public MemberExpression(Expression expression, PseudoField field) {
     super(ExpressionType.MemberAccess, field.getType());
-    this.expression = expression;
-    this.field = field;
+    assert field != null : "field should not be null";
     assert expression != null || Modifier.isStatic(field.getModifiers())
         : "must specify expression if field is not static";
+    this.expression = expression;
+    this.field = field;
   }
 
   @Override
@@ -70,6 +71,39 @@ public class MemberExpression extends Expression {
       writer.append(field.getDeclaringClass());
     }
     writer.append('.').append(field.getName());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    MemberExpression that = (MemberExpression) o;
+
+    if (expression != null ? !expression.equals(that.expression) : that
+        .expression != null) {
+      return false;
+    }
+    if (!field.equals(that.field)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (expression != null ? expression.hashCode() : 0);
+    result = 31 * result + field.hashCode();
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/MethodCallExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/MethodCallExpression.java
@@ -17,8 +17,6 @@
 */
 package net.hydromatic.linq4j.expressions;
 
-import net.hydromatic.linq4j.Linq4j;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -32,46 +30,27 @@ public class MethodCallExpression extends Expression {
   public final Method method;
   public final Expression targetExpression; // null for call to static method
   public final List<Expression> expressions;
+  /**
+   * Cache the hash code for the expression
+   */
+  private int hash;
 
   MethodCallExpression(Type returnType, Method method,
       Expression targetExpression, List<Expression> expressions) {
     super(ExpressionType.Call, returnType);
-    this.method = method;
-    this.targetExpression = targetExpression;
-    this.expressions = expressions;
-    assert expressions != null;
-    assert returnType != null;
+    assert expressions != null : "expressions should not be null";
+    assert method != null : "method should not be null";
     assert (targetExpression == null) == Modifier.isStatic(
         method.getModifiers());
     assert Types.toClass(returnType) == method.getReturnType();
+    this.method = method;
+    this.targetExpression = targetExpression;
+    this.expressions = expressions;
   }
 
   MethodCallExpression(Method method, Expression targetExpression,
       List<Expression> expressions) {
     this(method.getGenericReturnType(), method, targetExpression, expressions);
-  }
-
-  @Override
-  public int hashCode() {
-    return nodeType.hashCode()
-           ^ method.hashCode()
-           ^ targetExpression.hashCode()
-           ^ expressions.hashCode();
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj instanceof MethodCallExpression) {
-      final MethodCallExpression call = (MethodCallExpression) obj;
-      return nodeType == call.nodeType
-          && method == call.method
-          && Linq4j.equals(targetExpression, call.targetExpression)
-          && expressions.equals(call.expressions);
-    }
-    return false;
   }
 
   @Override
@@ -126,6 +105,51 @@ public class MethodCallExpression extends Expression {
       expression.accept(writer, 0, 0);
     }
     writer.append(')');
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    MethodCallExpression that = (MethodCallExpression) o;
+
+    if (!expressions.equals(that.expressions)) {
+      return false;
+    }
+    if (!method.equals(that.method)) {
+      return false;
+    }
+    if (targetExpression != null ? !targetExpression.equals(that
+        .targetExpression) : that.targetExpression != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = hash;
+    if (result == 0) {
+      result = super.hashCode();
+      result = 31 * result + method.hashCode();
+      result = 31 * result + (targetExpression != null ? targetExpression
+          .hashCode() : 0);
+      result = 31 * result + expressions.hashCode();
+      if (result == 0) {
+        result = 1;
+      }
+      hash = result;
+    }
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/MethodDeclaration.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/MethodDeclaration.java
@@ -34,6 +34,10 @@ public class MethodDeclaration extends MemberDeclaration {
 
   public MethodDeclaration(int modifier, String name, Type resultType,
       List<ParameterExpression> parameters, BlockStatement body) {
+    assert name != null : "name should not be null";
+    assert resultType != null : "resultType should not be null";
+    assert parameters != null : "parameters should not be null";
+    assert body != null : "body should not be null";
     this.modifier = modifier;
     this.name = name;
     this.resultType = resultType;
@@ -65,6 +69,46 @@ public class MethodDeclaration extends MemberDeclaration {
           }
         }).append(' ').append(body);
     writer.newlineAndIndent();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MethodDeclaration that = (MethodDeclaration) o;
+
+    if (modifier != that.modifier) {
+      return false;
+    }
+    if (!body.equals(that.body)) {
+      return false;
+    }
+    if (!name.equals(that.name)) {
+      return false;
+    }
+    if (!parameters.equals(that.parameters)) {
+      return false;
+    }
+    if (!resultType.equals(that.resultType)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = modifier;
+    result = 31 * result + name.hashCode();
+    result = 31 * result + resultType.hashCode();
+    result = 31 * result + parameters.hashCode();
+    result = 31 * result + body.hashCode();
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/NewArrayExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/NewArrayExpression.java
@@ -28,6 +28,10 @@ public class NewArrayExpression extends Expression {
   public final int dimension;
   public final Expression bound;
   public final List<Expression> expressions;
+  /**
+   * Cache the hash code for the expression
+   */
+  private int hash;
 
   public NewArrayExpression(Type type, int dimension, Expression bound,
       List<Expression> expressions) {
@@ -60,6 +64,50 @@ public class NewArrayExpression extends Expression {
     if (expressions != null) {
       writer.list(" {\n", ",\n", "}", expressions);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    NewArrayExpression that = (NewArrayExpression) o;
+
+    if (dimension != that.dimension) {
+      return false;
+    }
+    if (bound != null ? !bound.equals(that.bound) : that.bound != null) {
+      return false;
+    }
+    if (expressions != null ? !expressions.equals(that.expressions) : that
+        .expressions != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = hash;
+    if (result == 0) {
+      result = super.hashCode();
+      result = 31 * result + dimension;
+      result = 31 * result + (bound != null ? bound.hashCode() : 0);
+      result = 31 * result + (expressions != null ? expressions.hashCode() : 0);
+      if (result == 0) {
+        result = 1;
+      }
+      hash = result;
+    }
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/NewExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/NewExpression.java
@@ -30,6 +30,10 @@ public class NewExpression extends Expression {
   public final Type type;
   public final List<Expression> arguments;
   public final List<MemberDeclaration> memberDeclarations;
+  /**
+   * Cache the hash code for the expression
+   */
+  private int hash;
 
   public NewExpression(Type type, List<Expression> arguments,
       List<MemberDeclaration> memberDeclarations) {
@@ -54,6 +58,53 @@ public class NewExpression extends Expression {
     if (memberDeclarations != null) {
       writer.list("{\n", "", "}", memberDeclarations);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    NewExpression that = (NewExpression) o;
+
+    if (arguments != null ? !arguments.equals(that.arguments)
+        : that.arguments != null) {
+      return false;
+    }
+    if (memberDeclarations
+        != null ? !memberDeclarations.equals(that.memberDeclarations)
+        : that.memberDeclarations != null) {
+      return false;
+    }
+    if (!type.equals(that.type)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = hash;
+    if (result == 0) {
+      result = super.hashCode();
+      result = 31 * result + type.hashCode();
+      result = 31 * result + (arguments != null ? arguments.hashCode() : 0);
+      result = 31 * result + (
+          memberDeclarations != null ? memberDeclarations.hashCode() : 0);
+      if (result == 0) {
+        result = 1;
+      }
+      hash = result;
+    }
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/ParameterExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/ParameterExpression.java
@@ -35,6 +35,7 @@ public class ParameterExpression extends Expression {
 
   public ParameterExpression(int modifier, Type type, String name) {
     super(ExpressionType.Parameter, type);
+    assert name != null : "name should not be null";
     this.modifier = modifier;
     this.name = name;
   }
@@ -64,6 +65,16 @@ public class ParameterExpression extends Expression {
         + Types.className(type)
         + " "
         + name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return this == o;
+  }
+
+  @Override
+  public int hashCode() {
+    return System.identityHashCode(this);
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/ReflectedPseudoField.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/ReflectedPseudoField.java
@@ -17,17 +17,38 @@
 */
 package net.hydromatic.linq4j.expressions;
 
-/**
- * Represents a catch statement in a try block.
- */
-public class CatchBlock {
-  public final ParameterExpression parameter;
-  public final Statement body;
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
 
-  public CatchBlock(ParameterExpression parameter,
-      Statement body) {
-    this.parameter = parameter;
-    this.body = body;
+/**
+ * Represents a PseudoField that is implemented via java reflection Field
+ */
+public class ReflectedPseudoField implements PseudoField {
+  private final Field field;
+
+  public ReflectedPseudoField(Field field) {
+    assert field != null : "field should not be null";
+    this.field = field;
+  }
+
+  public String getName() {
+    return field.getName();
+  }
+
+  public Type getType() {
+    return field.getType();
+  }
+
+  public int getModifiers() {
+    return field.getModifiers();
+  }
+
+  public Object get(Object o) throws IllegalAccessException {
+    return field.get(o);
+  }
+
+  public Class<?> getDeclaringClass() {
+    return field.getDeclaringClass();
   }
 
   @Override
@@ -39,13 +60,9 @@ public class CatchBlock {
       return false;
     }
 
-    CatchBlock that = (CatchBlock) o;
+    ReflectedPseudoField that = (ReflectedPseudoField) o;
 
-    if (body != null ? !body.equals(that.body) : that.body != null) {
-      return false;
-    }
-    if (parameter != null ? !parameter.equals(that.parameter) : that
-        .parameter != null) {
+    if (!field.equals(that.field)) {
       return false;
     }
 
@@ -54,10 +71,6 @@ public class CatchBlock {
 
   @Override
   public int hashCode() {
-    int result = parameter != null ? parameter.hashCode() : 0;
-    result = 31 * result + (body != null ? body.hashCode() : 0);
-    return result;
+    return field.hashCode();
   }
 }
-
-// End CatchBlock.java

--- a/src/main/java/net/hydromatic/linq4j/expressions/TernaryExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/TernaryExpression.java
@@ -30,6 +30,9 @@ public class TernaryExpression extends Expression {
   TernaryExpression(ExpressionType nodeType, Type type, Expression expression0,
       Expression expression1, Expression expression2) {
     super(nodeType, type);
+    assert expression0 != null : "expression0 should not be null";
+    assert expression1 != null : "expression1 should not be null";
+    assert expression2 != null : "expression2 should not be null";
     this.expression0 = expression0;
     this.expression1 = expression1;
     this.expression2 = expression2;
@@ -52,6 +55,42 @@ public class TernaryExpression extends Expression {
     expression1.accept(writer, nodeType.rprec, nodeType.lprec);
     writer.append(nodeType.op2);
     expression2.accept(writer, nodeType.rprec, rprec);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    TernaryExpression that = (TernaryExpression) o;
+
+    if (!expression0.equals(that.expression0)) {
+      return false;
+    }
+    if (!expression1.equals(that.expression1)) {
+      return false;
+    }
+    if (!expression2.equals(that.expression2)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + expression0.hashCode();
+    result = 31 * result + expression1.hashCode();
+    result = 31 * result + expression2.hashCode();
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/ThrowStatement.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/ThrowStatement.java
@@ -37,6 +37,35 @@ public class ThrowStatement extends Statement {
   void accept0(ExpressionWriter writer) {
     writer.append("throw ").append(expression).append(';').newlineAndIndent();
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    ThrowStatement that = (ThrowStatement) o;
+
+    if (expression != null ? !expression.equals(that.expression) : that
+        .expression != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (expression != null ? expression.hashCode() : 0);
+    return result;
+  }
 }
 
 // End ThrowStatement.java

--- a/src/main/java/net/hydromatic/linq4j/expressions/TryStatement.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/TryStatement.java
@@ -30,6 +30,8 @@ public class TryStatement extends Statement {
   public TryStatement(Statement body, List<CatchBlock> catchBlocks,
       Statement fynally) {
     super(ExpressionType.Try, body.getType());
+    assert body != null : "body should not be null";
+    assert catchBlocks != null : "catchBlocks should not be null";
     this.body = body;
     this.catchBlocks = catchBlocks;
     this.fynally = fynally;
@@ -52,6 +54,43 @@ public class TryStatement extends Statement {
       writer.backUp();
       writer.append(" finally ").append(Blocks.toBlock(fynally));
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    TryStatement that = (TryStatement) o;
+
+    if (!body.equals(that.body)) {
+      return false;
+    }
+    if (!catchBlocks.equals(that.catchBlocks)) {
+      return false;
+    }
+    if (fynally != null ? !fynally.equals(that.fynally) : that.fynally
+        != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + body.hashCode();
+    result = 31 * result + catchBlocks.hashCode();
+    result = 31 * result + (fynally != null ? fynally.hashCode() : 0);
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/TypeBinaryExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/TypeBinaryExpression.java
@@ -29,6 +29,7 @@ public class TypeBinaryExpression extends Expression {
   public TypeBinaryExpression(ExpressionType nodeType, Expression expression,
       Type type) {
     super(nodeType, Boolean.TYPE);
+    assert expression != null : "expression should not be null";
     this.expression = expression;
     this.type = type;
   }
@@ -46,6 +47,38 @@ public class TypeBinaryExpression extends Expression {
     expression.accept(writer, lprec, nodeType.lprec);
     writer.append(nodeType.op);
     writer.append(type);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    TypeBinaryExpression that = (TypeBinaryExpression) o;
+
+    if (!expression.equals(that.expression)) {
+      return false;
+    }
+    if (type != null ? !type.equals(that.type) : that.type != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + expression.hashCode();
+    result = 31 * result + (type != null ? type.hashCode() : 0);
+    return result;
   }
 }
 

--- a/src/main/java/net/hydromatic/linq4j/expressions/Types.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/Types.java
@@ -120,31 +120,7 @@ public abstract class Types {
   private static RecordField getSystemField(final String fieldName,
       final Class clazz) {
     // The "length" field of an array does not appear in Class.getFields().
-    return new RecordField() {
-      public boolean nullable() {
-        return false;
-      }
-
-      public String getName() {
-        return fieldName;
-      }
-
-      public Type getType() {
-        return int.class;
-      }
-
-      public int getModifiers() {
-        return 0;
-      }
-
-      public Object get(Object o) throws IllegalAccessException {
-        return Array.getLength(o);
-      }
-
-      public Type getDeclaringClass() {
-        return clazz;
-      }
-    };
+    return new ArrayLengthRecordField(fieldName, clazz);
   }
 
   public static Class toClass(Type type) {
@@ -490,27 +466,7 @@ public abstract class Types {
   }
 
   public static PseudoField field(final Field field) {
-    return new PseudoField() {
-      public String getName() {
-        return field.getName();
-      }
-
-      public Type getType() {
-        return field.getType();
-      }
-
-      public int getModifiers() {
-        return field.getModifiers();
-      }
-
-      public Object get(Object o) throws IllegalAccessException {
-        return field.get(o);
-      }
-
-      public Class<?> getDeclaringClass() {
-        return field.getDeclaringClass();
-      }
-    };
+    return new ReflectedPseudoField(field);
   }
 
   static Class arrayClass(Type type) {

--- a/src/main/java/net/hydromatic/linq4j/expressions/UnaryExpression.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/UnaryExpression.java
@@ -27,6 +27,7 @@ public class UnaryExpression extends Expression {
 
   UnaryExpression(ExpressionType nodeType, Type type, Expression expression) {
     super(nodeType, type);
+    assert expression != null : "expression should not be null";
     this.expression = expression;
   }
 
@@ -34,25 +35,6 @@ public class UnaryExpression extends Expression {
   public Expression accept(Visitor visitor) {
     Expression expression = this.expression.accept(visitor);
     return visitor.visit(this, expression);
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (obj == this) {
-      return true;
-    }
-    if (obj instanceof UnaryExpression) {
-      final UnaryExpression unaryExpression = (UnaryExpression) obj;
-      return nodeType == unaryExpression.nodeType
-          && type.equals(unaryExpression.type)
-          && expression.equals(unaryExpression.expression);
-    }
-    return false;
-  }
-
-  @Override
-  public int hashCode() {
-    return nodeType.hashCode() ^ expression.hashCode();
   }
 
   void accept(ExpressionWriter writer, int lprec, int rprec) {
@@ -71,6 +53,34 @@ public class UnaryExpression extends Expression {
       writer.append(nodeType.op);
       expression.accept(writer, nodeType.lprec, rprec);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    UnaryExpression that = (UnaryExpression) o;
+
+    if (!expression.equals(that.expression)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + expression.hashCode();
+    return result;
   }
 }
 


### PR DESCRIPTION
Proper equals/hashCode allows to detect duplicate expressions in BlockBuilder.
All the Expressions/Statements implement typical equals/hashCode provided by IntellijIDEA
ParameterExpression implement identity equals/hashCode

Hash codes for complex expressions are cached into a field of the expression.
