### PR TITLE
Enable usage of custom optimizers in BlockBuilder

### DIFF
--- a/src/main/java/net/hydromatic/linq4j/expressions/BlockBuilder.java
+++ b/src/main/java/net/hydromatic/linq4j/expressions/BlockBuilder.java
@@ -27,6 +27,8 @@ import java.util.*;
  * <p>Has methods that help ensure that variable names are unique.</p>
  */
 public class BlockBuilder {
+  private static final Visitor OPTIMIZE_VISITOR = new OptimizeVisitor();
+
   final List<Statement> statements = new ArrayList<Statement>();
   final Set<String> variables = new HashSet<String>();
   /** Contains final-fine-to-reuse-declarations.
@@ -319,7 +321,7 @@ public class BlockBuilder {
         new IdentityHashMap<ParameterExpression, Expression>();
     final SubstituteVariableVisitor visitor = new SubstituteVariableVisitor(
         subMap);
-    final OptimizeVisitor optimizer = new OptimizeVisitor();
+    final Visitor optimizer = createOptimizeVisitor();
     final ArrayList<Statement> oldStatements = new ArrayList<Statement>(
         statements);
     statements.clear();
@@ -382,6 +384,17 @@ public class BlockBuilder {
         }
       }
     }
+  }
+
+  /**
+   * Creates a visitor that will be used during block optimization.
+   * Subclasses might provide more specific optimizations (e.g. partial
+   * evaluation).
+   *
+   * @return visitor used to optimize the statements when converting to block
+   */
+  protected Visitor createOptimizeVisitor() {
+    return OPTIMIZE_VISITOR;
   }
 
   /**

--- a/src/test/java/net/hydromatic/linq4j/test/BlockBuilderTest.java
+++ b/src/test/java/net/hydromatic/linq4j/test/BlockBuilderTest.java
@@ -17,9 +17,7 @@
 */
 package net.hydromatic.linq4j.test;
 
-import net.hydromatic.linq4j.expressions.BlockBuilder;
-import net.hydromatic.linq4j.expressions.Expression;
-import net.hydromatic.linq4j.expressions.Expressions;
+import net.hydromatic.linq4j.expressions.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -52,4 +50,26 @@ public class BlockBuilderTest extends BlockBuilderBase {
                  + "}\n", b.toBlock().toString());
   }
 
+  @Test
+  public void testCustomOptimizer() {
+    BlockBuilder b = new BlockBuilder() {
+      @Override
+      protected Visitor createOptimizeVisitor() {
+        return new OptimizeVisitor() {
+          @Override
+          public Expression visit(BinaryExpression binary,
+                                  Expression expression0,
+                                  Expression expression1) {
+            if (binary.getNodeType() == ExpressionType.Add
+                && ONE.equals(expression0) && TWO.equals(expression1)) {
+              return FOUR;
+            }
+            return super.visit(binary, expression0, expression1);
+          }
+        };
+      }
+    };
+    b.add(Expressions.return_(null, Expressions.add(ONE, TWO)));
+    assertEquals("{\n  return 4;\n}\n", b.toBlock().toString());
+  }
 }


### PR DESCRIPTION
This might be useful for optiq to perform evaluations at compile time (i.e. `upper("y") -> "Y"`)
